### PR TITLE
Replace feature="linux" with target_os="linux"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,16 @@ categories = ["command-line-utilities", "visualization"]
 homepage = "https://github.com/luis-ota/swaptop"
 documentation = "https://github.com/luis-ota/swaptop"
 
-[features]
-default = ["linux"]
-linux = ["procfs"]
-windows_support = ["tasklist", "sysinfo", "winapi"]
-
 [dependencies]
 ratatui = { version = "0.29.0", features = ["all-widgets"] }
 thiserror = "2.0.12"
 crossterm = "0.29.0"
 color-eyre = "0.6.3"
 
-procfs = { version = "0.17.0", optional = true }
-tasklist = { version = "0.3.0", optional = true }
-sysinfo = { version = "0.35.1", optional = true }
-winapi = { version = "0.3.9", features = ["memoryapi", "sysinfoapi", "winerror"], optional = true }
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = "0.17.0"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+tasklist = "0.3.0"
+sysinfo = "0.35.1"
+winapi = { version = "0.3.9", features = ["memoryapi", "sysinfoapi", "winerror"] }

--- a/src/swap_info.rs
+++ b/src/swap_info.rs
@@ -4,10 +4,8 @@ use thiserror::Error;
 #[cfg(target_os = "windows")]
 use std::io;
 
-#[cfg(feature = "linux")]
-use procfs::{self, Current};
-#[cfg(feature = "linux")]
-use procfs::Meminfo;
+#[cfg(target_os = "linux")]
+use procfs::{self, Current, Meminfo};
 
 
 #[derive(Debug, Clone)]
@@ -41,14 +39,12 @@ pub enum SwapDataError {
     Io(#[from] std::io::Error),
 }
 
-#[cfg(feature = "windows_support")]
 #[cfg(target_os = "windows")]
 #[derive(Debug, Error)]
 pub enum SwapDataError {
     #[error("I/O error accessing system information: {0}")]
     Io(#[from] io::Error),
 }
-#[cfg(feature = "linux")]
 #[cfg(target_os = "linux")]
 pub fn get_processes_using_swap(unit: SizeUnits) -> Result<Vec<ProcessSwapInfo>, SwapDataError> {
     let mut swap_processes = Vec::new();


### PR DESCRIPTION
Hello!

I tried to package this for Arch Linux and noticed the latest tagged release doesn't build by default because it needs the `linux` feature to be enabled. I assume this is to manage dependencies. :)

This patch uses a feature in Cargo to enable dependencies based on `target_os` and then removes the need for features (unless I've missed something).

cheers! 