### PR TITLE
Imp/cache issue 07

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,25 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-branch:
+    name: Check if tag is on main
+    runs-on: ubuntu-latest
+    outputs:
+      is_main: ${{ steps.check.outputs.is_main }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check tag ancestry
+        id: check
+        run: |
+          git fetch origin main
+          if git merge-base --is-ancestor HEAD origin/main; then
+            echo "is_main=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_main=false" >> $GITHUB_OUTPUT
+          fi
+
   build:
     name: Build for ${{ matrix.target_os }}
     runs-on: ubuntu-latest
@@ -159,7 +178,8 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, check-branch]
+    if: needs.check-branch.outputs.is_main == 'true'
     permissions:
       contents: write
     steps:
@@ -209,3 +229,20 @@ jobs:
             See attached assets for Linux and Windows.
           files: |
             release-assets/*/*
+
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: [build, check-branch]
+    if: needs.check-branch.outputs.is_main == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +372,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +398,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -414,6 +452,16 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "indoc"
@@ -475,6 +523,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,7 +570,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -610,6 +667,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "owo-colors"
@@ -751,6 +814,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -842,6 +917,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -941,12 +1025,15 @@ version = "1.0.5"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
+ "dirs",
  "proc-mounts",
  "procfs",
  "ratatui",
+ "serde",
  "sysinfo",
  "tasklist",
  "thiserror 2.0.17",
+ "toml",
  "winapi",
 ]
 
@@ -1054,6 +1141,47 @@ name = "time-core"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1439,3 +1567,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swaptop"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Luis Otavio <luotasss@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ ratatui = { version = "0.29.0", features = ["all-widgets"] }
 thiserror = "2.0.12"
 crossterm = "0.29.0"
 color-eyre = "0.6.3"
+dirs = "6"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.17.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,67 @@
+use crate::swap_info::SizeUnits;
+use crate::theme::ThemeType;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AppConfig {
+    pub aggregated: bool,
+    pub size_unit: SizeUnits,
+    pub display_devices: bool,
+    pub theme: ThemeType,
+    pub timeout: u64,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            aggregated: false,
+            size_unit: SizeUnits::KB,
+            display_devices: false,
+            theme: ThemeType::Dracula,
+            timeout: 1000,
+        }
+    }
+}
+
+fn config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("swaptop"))
+}
+
+fn config_path() -> Option<PathBuf> {
+    config_dir().map(|p| p.join("config.toml"))
+}
+
+pub fn load_config() -> AppConfig {
+    let Some(path) = config_path() else {
+        return AppConfig::default();
+    };
+
+    if !path.exists() {
+        return AppConfig::default();
+    }
+
+    match fs::read_to_string(&path) {
+        Ok(content) => toml::from_str(&content).unwrap_or_default(),
+        Err(_) => AppConfig::default(),
+    }
+}
+
+pub fn save_config(config: &AppConfig) {
+    let Some(dir) = config_dir() else {
+        return;
+    };
+
+    if fs::create_dir_all(&dir).is_err() {
+        return;
+    };
+
+    let Some(path) = config_path() else {
+        return;
+    };
+
+    if let Ok(content) = toml::to_string_pretty(config) {
+        let _ = fs::write(&path, content);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod swap_info;
 mod theme;
 
@@ -23,6 +24,15 @@ use std::time::{Duration, Instant};
 use swap_info::{SizeUnits, get_chart_info, get_processes_using_swap};
 
 const LINUX: bool = cfg!(target_os = "linux");
+
+fn format_swap_value(value: f64) -> String {
+    let rounded = value.round();
+    if (value - rounded).abs() < 0.01 {
+        format!("{}", rounded as u64)
+    } else {
+        format!("{:.2}", value)
+    }
+}
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
@@ -52,20 +62,21 @@ pub struct App {
 
 impl App {
     pub fn new() -> Self {
+        let cfg = config::load_config();
         Self {
             running: false,
-            display_devices: false,
+            display_devices: cfg.display_devices,
             vertical_scroll_state: ScrollbarState::default(),
             vertical_scroll: 0,
-            swap_size_unit: SizeUnits::KB,
+            swap_size_unit: cfg.size_unit,
             swap_processes_lines: Vec::new(),
             last_update: None,
             chart_info: SwapUpdate::default(),
-            aggregated: false,
-            current_theme: ThemeType::Dracula,
+            aggregated: cfg.aggregated,
+            current_theme: cfg.theme,
             time_window: [0.0, 60.0],
             chart_data: Vec::new(),
-            timeout: 1000,
+            timeout: cfg.timeout,
             visible_height: 0,
         }
     }
@@ -282,44 +293,54 @@ impl App {
                     self.vertical_scroll_state.position(self.vertical_scroll);
             }
 
-            // change unit
-            KeyCode::Char('k') => {
-                self.swap_size_unit = SizeUnits::KB;
-                if let Ok(info) = get_chart_info(self.swap_size_unit.clone()) {
-                    self.chart_info = info;
-                    self.swap_processes_lines = self.create_process_lines(self.aggregated);
-                }
+        // change unit
+        KeyCode::Char('k') => {
+            self.swap_size_unit = SizeUnits::KB;
+            if let Ok(info) = get_chart_info(self.swap_size_unit.clone()) {
+                self.chart_info = info;
+                self.swap_processes_lines = self.create_process_lines(self.aggregated);
             }
-            KeyCode::Char('m') => {
-                self.swap_size_unit = SizeUnits::MB;
-                if let Ok(info) = get_chart_info(self.swap_size_unit.clone()) {
-                    self.chart_info = info;
-                    self.swap_processes_lines = self.create_process_lines(self.aggregated);
-                }
+            self.save_app_config();
+        }
+        KeyCode::Char('m') => {
+            self.swap_size_unit = SizeUnits::MB;
+            if let Ok(info) = get_chart_info(self.swap_size_unit.clone()) {
+                self.chart_info = info;
+                self.swap_processes_lines = self.create_process_lines(self.aggregated);
             }
-            KeyCode::Char('g') => {
-                self.swap_size_unit = SizeUnits::GB;
-                if let Ok(info) = get_chart_info(self.swap_size_unit.clone()) {
-                    self.chart_info = info;
-                    self.swap_processes_lines = self.create_process_lines(self.aggregated);
-                }
+            self.save_app_config();
+        }
+        KeyCode::Char('g') => {
+            self.swap_size_unit = SizeUnits::GB;
+            if let Ok(info) = get_chart_info(self.swap_size_unit.clone()) {
+                self.chart_info = info;
+                self.swap_processes_lines = self.create_process_lines(self.aggregated);
             }
+            self.save_app_config();
+        }
 
-            // aggregate
-            KeyCode::Char('a') => self.aggregated = !self.aggregated,
+        // aggregate
+        KeyCode::Char('a') => {
+            self.aggregated = !self.aggregated;
+            self.save_app_config();
+        }
 
-            // change theme
-            KeyCode::Char('t') => self.cycle_theme(),
+        // change theme
+        KeyCode::Char('t') => self.cycle_theme(),
 
-            // display swap devices
-            KeyCode::Char('h') => {
-                if LINUX {
-                    self.display_devices = !self.display_devices
-                }
+        // display swap devices
+        KeyCode::Char('h') => {
+            if LINUX {
+                self.display_devices = !self.display_devices;
+                self.save_app_config();
             }
+        }
 
-            // change timeout
-            KeyCode::Left | KeyCode::Right => self.change_timout(key.code),
+        // change timeout
+        KeyCode::Left | KeyCode::Right => {
+            self.change_timout(key.code);
+            self.save_app_config();
+        }
 
             _ => {}
         }
@@ -374,44 +395,54 @@ impl App {
                     self.vertical_scroll_state.position(self.vertical_scroll);
             }
 
-            // change unit
-            KeyCode::Char('k') => {
-                self.swap_size_unit = SizeUnits::KB;
-                if let Ok(info) = get_chart_info() {
-                    self.chart_info = info;
-                    self.swap_processes_lines = self.create_process_lines(self.aggregated);
-                }
+        // change unit
+        KeyCode::Char('k') => {
+            self.swap_size_unit = SizeUnits::KB;
+            if let Ok(info) = get_chart_info() {
+                self.chart_info = info;
+                self.swap_processes_lines = self.create_process_lines(self.aggregated);
             }
-            KeyCode::Char('m') => {
-                self.swap_size_unit = SizeUnits::MB;
-                if let Ok(info) = get_chart_info() {
-                    self.chart_info = info;
-                    self.swap_processes_lines = self.create_process_lines(self.aggregated);
-                }
+            self.save_app_config();
+        }
+        KeyCode::Char('m') => {
+            self.swap_size_unit = SizeUnits::MB;
+            if let Ok(info) = get_chart_info() {
+                self.chart_info = info;
+                self.swap_processes_lines = self.create_process_lines(self.aggregated);
             }
-            KeyCode::Char('g') => {
-                self.swap_size_unit = SizeUnits::GB;
-                if let Ok(info) = get_chart_info() {
-                    self.chart_info = info;
-                    self.swap_processes_lines = self.create_process_lines(self.aggregated);
-                }
+            self.save_app_config();
+        }
+        KeyCode::Char('g') => {
+            self.swap_size_unit = SizeUnits::GB;
+            if let Ok(info) = get_chart_info() {
+                self.chart_info = info;
+                self.swap_processes_lines = self.create_process_lines(self.aggregated);
             }
+            self.save_app_config();
+        }
 
-            // aggregate
-            KeyCode::Char('a') => self.aggregated = !self.aggregated,
+        // aggregate
+        KeyCode::Char('a') => {
+            self.aggregated = !self.aggregated;
+            self.save_app_config();
+        }
 
-            // change theme
-            KeyCode::Char('t') => self.cycle_theme(),
+        // change theme
+        KeyCode::Char('t') => self.cycle_theme(),
 
-            // display swap devices
-            KeyCode::Char('h') => {
-                if LINUX {
-                    self.display_devices = !self.display_devices
-                }
+        // display swap devices
+        KeyCode::Char('h') => {
+            if LINUX {
+                self.display_devices = !self.display_devices;
+                self.save_app_config();
             }
+        }
 
-            // change timeout
-            KeyCode::Left | KeyCode::Right => self.change_timout(key.code),
+        // change timeout
+        KeyCode::Left | KeyCode::Right => {
+            self.change_timout(key.code);
+            self.save_app_config();
+        }
 
             _ => {}
         }
@@ -426,6 +457,17 @@ impl App {
             ThemeType::Nord => ThemeType::Default,
         };
         self.swap_processes_lines = self.create_process_lines(self.aggregated);
+        self.save_app_config();
+    }
+
+    fn save_app_config(&self) {
+        config::save_config(&config::AppConfig {
+            aggregated: self.aggregated,
+            size_unit: self.swap_size_unit.clone(),
+            display_devices: self.display_devices,
+            theme: self.current_theme,
+            timeout: self.timeout,
+        });
     }
 
     fn change_timout(&mut self, action: KeyCode) {
@@ -465,11 +507,8 @@ impl App {
                 processes = aggregate_processes(processes);
             }
 
-            for process in processes {
-                let mut process_size: String = format!("{:.2}", process.swap_size);
-                if let SizeUnits::KB = self.swap_size_unit {
-                    process_size = format!("{}", process.swap_size)
-                }
+        for process in processes {
+            let process_size = format_swap_value(process.swap_size);
 
                 lines.push(Line::from(vec![
                     format!("{:12}", process.pid).into(),
@@ -488,13 +527,7 @@ impl App {
         let total = convert_swap(self.chart_info.total_swap, self.swap_size_unit.clone());
         let used = convert_swap(self.chart_info.used_swap, self.swap_size_unit.clone());
 
-        let total_used_title: String = match self.swap_size_unit {
-            SizeUnits::KB => format!("total: {} | used: {}", total, used),
-            SizeUnits::MB => format!("total: {} | used: {:.2}", total.round(), used),
-            SizeUnits::GB => format!("total: {:.2} | used: {:.2}", total, used),
-        };
-
-        total_used_title
+        format!("total: {} | used: {}", format_swap_value(total), format_swap_value(used))
     }
 
     #[cfg(target_os = "linux")]
@@ -522,12 +555,12 @@ impl App {
             .iter()
             .map(|d| {
                 let src = find_mount_device(std::path::Path::new(&d.name))
-                    .unwrap_or_else(|| "RAM".into());
+                    .unwrap_or_else(|| "unknown".into());
                 src.len()
             })
             .max()
-            .unwrap_or(4)
-            .max(4);
+            .unwrap_or(7)
+            .max(7);
 
         let wide = area.width >= 80;
         let mut lines = Vec::new();
@@ -545,18 +578,12 @@ impl App {
         }
 
         for device in &self.chart_info.swap_devices {
-            let used = match self.swap_size_unit {
-                SizeUnits::KB => device.used_kb.to_string(),
-                _ => format!("{:.2}", device.used_kb),
-            };
+            let used = format_swap_value(device.used);
 
             let source = find_mount_device(std::path::Path::new(&device.name))
-                .unwrap_or_else(|| "RAM".into());
+                .unwrap_or_else(|| "unknown".into());
 
-            let total = match self.swap_size_unit {
-                SizeUnits::KB => device.size_kb.to_string(),
-                _ => format!("{:.2}", device.size_kb),
-            };
+            let total = format_swap_value(device.size);
 
             let row = if wide {
                 format!(
@@ -660,7 +687,11 @@ impl App {
             .border_style(Style::default().fg(theme.border))
             .style(Style::default().bg(theme.background))
             .title(
-                Line::from("(a to aggregate) (u/d|▲/▼|home/end|pgup/pgdown to scroll)")
+                Line::from(if self.aggregated {
+                    "(a to segregate) (u/d|▲/▼|home/end|pgup/pgdown to scroll)"
+                } else {
+                    "(a to aggregate) (u/d|▲/▼|home/end|pgup/pgdown to scroll)"
+                })
                     .fg(theme.text)
                     .right_aligned(),
             )

--- a/src/swap_info.rs
+++ b/src/swap_info.rs
@@ -21,8 +21,8 @@ pub struct ProcessSwapInfo {
 pub struct InfoSwap {
     pub name: String,
     pub kind: String,
-    pub size_kb: f64,
-    pub used_kb: f64,
+    pub size: f64,
+    pub used: f64,
     pub priority: isize,
 }
 
@@ -34,7 +34,7 @@ pub struct SwapUpdate {
     pub used_swap: u64,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub enum SizeUnits {
     #[default]
     KB,
@@ -66,8 +66,8 @@ pub fn get_swap_devices(unit: SizeUnits) -> std::io::Result<Vec<InfoSwap>> {
         out.push(InfoSwap {
             name: s.source.to_string_lossy().into_owned(),
             kind: s.kind.to_string_lossy().into_owned(),
-            size_kb: convert_swap(s.size as u64, unit.to_owned()),
-            used_kb: convert_swap(s.used as u64, unit.to_owned()),
+            size: convert_swap(s.size as u64, unit.to_owned()),
+            used: convert_swap(s.used as u64, unit.to_owned()),
             priority: s.priority,
         });
     }
@@ -103,6 +103,16 @@ pub fn get_processes_using_swap(unit: SizeUnits) -> Result<Vec<ProcessSwapInfo>,
 
 #[cfg(target_os = "linux")]
 pub fn find_mount_device(path: &std::path::Path) -> Option<String> {
+    let path_str = path.to_string_lossy();
+
+    if path_str.starts_with("/dev/zram") {
+        return Some("RAM".to_owned());
+    }
+
+    if path_str.starts_with("/dev/") {
+        return Some(path_str.into_owned());
+    }
+
     let abs_path = path.canonicalize().ok()?;
 
     let mountinfo = procfs::process::Process::myself()
@@ -114,11 +124,11 @@ pub fn find_mount_device(path: &std::path::Path) -> Option<String> {
         .filter(|m| abs_path.starts_with(&m.mount_point))
         .max_by_key(|m| m.mount_point.components().count())?;
 
-    Some(if best_mount.fs_type == "devtmpfs" {
-        "RAM".to_owned()
-    } else {
-        best_mount.mount_source?
-    })
+    if best_mount.fs_type == "devtmpfs" {
+        return None;
+    }
+
+    best_mount.mount_source
 }
 
 #[cfg(target_os = "windows")]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,6 +1,6 @@
 use ratatui::style::Color;
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
 pub enum ThemeType {
     #[default]
     Default,


### PR DESCRIPTION
Summary
This PR adds persistent state caching and improves the release workflow safety.
Changes
1. Persistent config/cache file (src/config.rs)
- Saves and restores the tool state (swap info, theme, etc.) when you close and reopen the tool
- No more losing your view/settings between sessions
2. Release workflow safety (.github/workflows/release.yml)
- Added check-branch job that verifies the tag is on main before creating a release
- release and publish jobs only run when the tag is on main — prevents accidental GitHub Releases or crates.io publishes from non-main branches
- Added publish job that runs cargo publish automatically when a v*.*.* tag is pushed on main
3. Version bump to 1.0.6
Files changed
- src/config.rs — new config/cache persistence module
- src/main.rs — integrate config loading/saving
- src/swap_info.rs — adjustments for caching
- .github/workflows/release.yml — branch guard + auto-publish to crates.io
- Cargo.toml — version 1.0.6
- Cargo.lock — updated dependencies